### PR TITLE
fix: Remove unwanted user info popup from room

### DIFF
--- a/room.html
+++ b/room.html
@@ -69,14 +69,6 @@
   </div>
 
   <!-- Popups and other hidden elements -->
-  <div id="user-info-popup" class="popup">
-    <div class="popup-content">
-      <p id="user-name">👤 الاسم: </p>
-      <p id="user-id">🆔 ID: </p>
-      <button onclick="copyUserId()">📋 نسخ ID</button>
-      <button onclick="closePopup()">❌ إغلاق</button>
-    </div>
-  </div>
 
   <div id="admin-controls" class="popup" style="display:none;">
       <div class="popup-content">


### PR DESCRIPTION
This commit removes the user info popup (`div#user-info-popup`) from `room.html`.

The popup was appearing immediately upon entering the room due to a CSS change and was identified by the user as an unwanted element. This change deletes the popup's HTML entirely to prevent it from appearing and to clean up the code.