### PR TITLE
feat: Implement improved admin kick UI

### DIFF
--- a/room.css
+++ b/room.css
@@ -506,3 +506,22 @@ body {
   transform: scale(1.05);
   opacity: 1;
 }
+
+/* Kick Modal Specifics */
+.kick-confirm-actions {
+    display: flex;
+    justify-content: center;
+    gap: 15px;
+    margin-top: 20px;
+}
+
+.destructive-btn {
+    background-color: #c3073f !important; /* Use important to override general popup button styles */
+    color: white !important;
+    border-color: #950740 !important;
+}
+
+.destructive-btn:hover {
+    background-color: #950740 !important;
+    border-color: #c3073f !important;
+}

--- a/room.html
+++ b/room.html
@@ -167,6 +167,21 @@
     </div>
   </div>
 
+  <!-- Kick Confirmation Modal -->
+  <div id="kick-confirm-modal" class="popup" style="display: none;">
+    <div class="popup-content">
+      <div class="popup-header">
+        <h3>تأكيد الطرد</h3>
+        <button onclick="closeKickModal()" class="close-button">❌</button>
+      </div>
+      <p>هل أنت متأكد من رغبتك في طرد المستخدم <strong id="kick-user-name"></strong>؟</p>
+      <div class="kick-confirm-actions">
+        <button id="confirm-kick-btn" onclick="banUser()" class="destructive-btn">نعم، قم بالطرد</button>
+        <button onclick="closeKickModal()">إلغاء</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Audio elements -->
   <audio id="mic-audio" src="mic-sound.mp3"></audio>
   <audio id="bg-music" src="bg-music.mp3" loop></audio>


### PR DESCRIPTION
This commit refactors the admin "kick" functionality to be more user-friendly. Instead of requiring the admin to manually type a user's ID, they can now click on a user in the "Online Users" list to kick them.

**Frontend Changes (`room.js`, `room.html`, `room.css`):**
- The user list is now dynamically generated from server data.
- An event listener on the user list allows admins to click on a user.
- A new confirmation modal (`#kick-confirm-modal`) has been added to prevent accidental kicks.
- The `banUser` function is now triggered by the confirmation modal and sends the correct socket ID to the server.

**Backend Changes (`server/server.js`):**
- The server now maintains a list of users with both their socket ID and username for each room.
- This up-to-date user list is broadcast to all clients in a room whenever a user joins or leaves.
- The `admin-kick-user` logic has been updated to forcefully disconnect the kicked user from the server.

This change significantly improves the moderation experience in the application.